### PR TITLE
Chest Wand working on modded chests

### DIFF
--- a/ChestHelper/ChestEntity.cs
+++ b/ChestHelper/ChestEntity.cs
@@ -79,7 +79,7 @@ namespace StructureHelper.ChestHelper
 		public override bool IsTileValidForEntity(int i, int j)
 		{
             var tile = Framing.GetTileSafely(i, j);
-            return tile.TileType == TileID.Containers;
+            return tile.TileType == TileID.Containers || TileID.Sets.BasicChest[tile.TileType];
 		}
 	}
 }

--- a/Generator.cs
+++ b/Generator.cs
@@ -226,7 +226,7 @@ namespace StructureHelper
                                 }
                             }
                         }
-                        else if (type == TileID.Containers && d.FrameX % 36 == 0 && d.FrameY % 36 == 0) //generate an empty chest if there is no chest data
+                        else if ((type == TileID.Containers || TileID.Sets.BasicChest[tile.TileType]) && d.FrameX % 36 == 0 && d.FrameY % 36 == 0) //generate an empty chest if there is no chest data
                             Chest.CreateChest(pos.X + x, pos.Y + y);
                     }
 

--- a/Items/ChestWand.cs
+++ b/Items/ChestWand.cs
@@ -33,7 +33,7 @@ namespace StructureHelper.Items
         {
             Tile tile = Framing.GetTileSafely(Player.tileTargetX, Player.tileTargetY);
 
-            if (tile.TileType == TileID.Containers)
+            if (tile.TileType == TileID.Containers || TileID.Sets.BasicChest[tile.TileType])
             {
                 int xOff = tile.TileFrameX % 36 / 18;
                 int yOff = tile.TileFrameY % 36 / 18;


### PR DESCRIPTION
Adds extra check for TileID.Sets.BasicChest, as long as the modded chest has that then it'll work