### PR TITLE
Support `TileWallBrightnessInvisibilityData`

### DIFF
--- a/Generator.cs
+++ b/Generator.cs
@@ -236,6 +236,13 @@ namespace StructureHelper
 							*shortPtr = d.packedLiquidData;
 						}
 
+						fixed (void* ptr = &tile.Get<TileWallBrightnessInvisibilityData>())
+						{
+							byte* bytePtr = (byte*)ptr;
+
+							*bytePtr = d.brightnessInvisibilityData;
+						}
+
 						if (!d.Active)
 							tile.HasTile = false;
 

--- a/Saver.cs
+++ b/Saver.cs
@@ -136,6 +136,7 @@ namespace StructureHelper
 
 					int wallWireData;
 					short packedLiquidData;
+					byte brightnessInvisibilityData;
 
 					fixed (void* ptr = &tile.Get<TileWallWireStateData>())
 					{
@@ -152,6 +153,13 @@ namespace StructureHelper
 						packedLiquidData = *shortPtr;
 					}
 
+					fixed (void* ptr = &tile.Get<TileWallBrightnessInvisibilityData>())
+					{
+						byte* bytePtr = (byte*)ptr;
+
+						brightnessInvisibilityData = *bytePtr;
+					}
+
 					data.Add(
 						new TileSaveData(
 							tileName,
@@ -160,6 +168,7 @@ namespace StructureHelper
 							tile.TileFrameY,
 							wallWireData,
 							packedLiquidData,
+							brightnessInvisibilityData,
 							teName,
 							entityTag
 							));

--- a/TileSaveData.cs
+++ b/TileSaveData.cs
@@ -33,6 +33,10 @@ namespace StructureHelper
 		/// The other part of the packed vanilla data about a tile
 		/// </summary>
 		public short packedLiquidData;
+		/// <summary>
+		/// The coating part (full-bright/invisible) of the packed vanilla data about a tile
+		/// </summary>
+		public byte brightnessInvisibilityData;
 
 		/// <summary>
 		/// The fully qualiified name of a modded tile entity, if one should exist here
@@ -50,7 +54,7 @@ namespace StructureHelper
 		/// </summary>
 		public bool Active => TileDataPacking.GetBit(wallWireData, 0);
 
-		public TileSaveData(string tile, string wall, short frameX, short frameY, int wallWireData, short packedLiquidData, string teType = "", TagCompound teData = null)
+		public TileSaveData(string tile, string wall, short frameX, short frameY, int wallWireData, short packedLiquidData, byte brightnessInvisibilityData, string teType = "", TagCompound teData = null)
 		{
 			this.tile = tile;
 			this.wall = wall;
@@ -58,6 +62,7 @@ namespace StructureHelper
 			this.frameY = frameY;
 			this.wallWireData = wallWireData;
 			this.packedLiquidData = packedLiquidData;
+			this.brightnessInvisibilityData = brightnessInvisibilityData;
 			TEType = teType;
 			TEData = teData;
 		}
@@ -76,7 +81,8 @@ namespace StructureHelper
 			tag.GetShort("FrameY"),
 
 			tag.GetInt("WallWireData"),
-			tag.GetShort("PackedLiquidData")
+			tag.GetShort("PackedLiquidData"),
+			tag.GetByte("BrightnessInvisibilityData")
 			);
 
 			if (tag.ContainsKey("TEType"))
@@ -102,7 +108,8 @@ namespace StructureHelper
 				["FrameY"] = frameY,
 
 				["WallWireData"] = wallWireData,
-				["PackedLiquidData"] = packedLiquidData
+				["PackedLiquidData"] = packedLiquidData,
+				["BrightnessInvisibilityData"] = brightnessInvisibilityData
 			};
 
 			if (TEType != "")


### PR DESCRIPTION
Currently Structure Helper doesn't save `TileWallBrightnessInvisibilityData`, resulting in tiles and wall coatings not being saved and generated. This pr implements support for `TileWallBrightnessInvisibilityData`